### PR TITLE
fix(utils): ensure_package celuje w właściwy interpreter Pythona

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -972,11 +972,14 @@ def ensure_package(pip_name, import_name=None):
     if shutil.which("uv"):
         try:
             subprocess.check_call(
-                ["uv", "pip", "install", "--quiet", pip_name],
+                ["uv", "pip", "install", "--quiet",
+                 "--python", sys.executable, pip_name],
                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             )
+            __import__(import_name)
             return
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except (subprocess.CalledProcessError, FileNotFoundError,
+                ImportError):
             pass
 
     # 2) python -m pip — Docker, Colab, zwykły venv


### PR DESCRIPTION
## Summary
- `ensure_package()` z `uv pip install` bez `--python sys.executable` instalował pakiety do domyślnego środowiska uv zamiast do aktywnego venv-a
- Dodano `--python sys.executable` + weryfikacja `__import__` po instalacji (fallback do pip jeśli import nie zadziała)

## Kontekst
Audyt 4 notebooków (Reprezentacja_tekstu, Model_Języka, Function_Calling, RAG_warsztat) × 3 plany (UV, Docker, Colab) — wszystkie PASS. Jedyny znaleziony problem to ten edge case w `ensure_package()`.

## Test plan
- [x] Fresh UV env: `uv venv` + `uv sync --active` → tiktoken via ensure_package ✓
- [x] Fresh pip venv z uv na PATH: `python3.11 -m venv` + `pip install -r requirements.txt` → instructor via ensure_package ✓
- [x] 4 notebooki × 3 plany = 12 kombinacji przetestowanych przez równoległych agentów