### PR TITLE
fix: dodaj encoding='utf-8' do open() dla pliku GloVe

### DIFF
--- a/Reprezentacja_tekstu.ipynb
+++ b/Reprezentacja_tekstu.ipynb
@@ -1797,7 +1797,7 @@
     "\n",
     "print('Wczytuję embeddingi...')\n",
     "glove_embeddings = {}\n",
-    "with open(glove_file) as f:\n",
+    "with open(glove_file, encoding='utf-8') as f:\n",
     "    glove_embeddings = {l.split()[0]: np.array(l.split()[1:]).astype('float') for l in f}\n",
     "print(f'Wczytano {len(glove_embeddings)} słów.')"
    ]


### PR DESCRIPTION
## Summary
- Dodaje jawne `encoding='utf-8'` przy otwieraniu pliku GloVe w notebooku Reprezentacja_tekstu
- Na macOS domyślne kodowanie to UTF-8, więc działało bez tego, ale na Windows (cp1252/cp1250) powodowało `UnicodeDecodeError`

## Test plan
- [x] `przed_zajeciami.py` przeszło — stuby zresetowane, outputy czyste
- [x] Diff to dokładnie 1 zmieniona linia